### PR TITLE
fix: match geography/geometry OIDs correctly

### DIFF
--- a/geom.go
+++ b/geom.go
@@ -181,7 +181,7 @@ func (p geometryTextScanPlan) Scan(src []byte, target any) error {
 // registerGeom registers codecs for [*github.com/twpayne/go-geos.Geom] types on conn.
 func registerGeom(ctx context.Context, conn *pgx.Conn, geosContext *geos.Context) error {
 	var geographyOID, geometryOID uint32
-	err := conn.QueryRow(ctx, "select 'geography'::text::regtype::oid, 'geometry'::text::regtype::oid").Scan(&geometryOID, &geographyOID)
+	err := conn.QueryRow(ctx, "select 'geography'::text::regtype::oid, 'geometry'::text::regtype::oid").Scan(&geographyOID, &geometryOID)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This is probably not a particularly important change, but I happened to notice that `geography` and `geometry` got swapped here, so I figured I might offer a drive-by fix.