### PR TITLE
fix: register geos codecs in postgis example main.go

### DIFF
--- a/examples/postgis/main_test.go
+++ b/examples/postgis/main_test.go
@@ -13,8 +13,6 @@ import (
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
 	"github.com/testcontainers/testcontainers-go/wait"
-	"github.com/twpayne/go-geos"
-	pgxgeos "github.com/twpayne/pgx-geos"
 )
 
 func TestIntegration(t *testing.T) {
@@ -54,7 +52,7 @@ func TestIntegration(t *testing.T) {
 
 	conn, err := pgx.Connect(ctx, connStr)
 	assert.NoError(t, err)
-	assert.NoError(t, pgxgeos.Register(ctx, conn, geos.NewContext()))
+	assert.NoError(t, registerGeos(ctx, conn))
 
 	assert.NoError(t, createDB(ctx, conn))
 


### PR DESCRIPTION
This fix is required to make `main.go` work. 

Without it the following error is raised, even though `main_test.go` works fine:

```
go run examples/postgis/main.go --write
can't scan into dest[2]: cannot scan unknown type (OID 20937) in text format into **geos.Geom
exit status 1
```